### PR TITLE
Adapt to new format of dumps index page

### DIFF
--- a/lib/wp_download/download.py
+++ b/lib/wp_download/download.py
@@ -337,7 +337,7 @@ class URLHandler(object):
         self._config = config
 
         self._urlopener = urllib.FancyURLopener()
-        self._date_matcher = re.compile(r'<a href="(\d{8})/">\1</a>')
+        self._date_matcher = re.compile(r'<a href="(\d{8})/">\1/</a>')
 
         self._host = self._config.get('Configuration', 'base_url')
 


### PR DESCRIPTION
Up to Dec 2014, pages like http://dumps.wikimedia.org/cawiki/ had this format
```<a href="20140722/">20140722</a>```
Now they have format
```<a href="20140828/">20140828/</a> ```