### PR TITLE
Allow setting custom dump date via option --custom-dump

### DIFF
--- a/lib/wp_download/download.py
+++ b/lib/wp_download/download.py
@@ -95,7 +95,7 @@ class WPDownloader(object):
         """
         self._options = options
         self._config = wpd_conf.Configuration(options)
-        self._urlhandler = URLHandler(options, self._config)
+        self._urlhandler = URLHandler(self._config, options)
         self._downloader = urllib.FancyURLopener()
 
         LOG.info('Set timeout to %d' % (options.timeout))
@@ -326,7 +326,7 @@ class URLHandler(object):
     Handler for Wikipedia dump download URLs
     """
 
-    def __init__(self, options, config):
+    def __init__(self, config, options=None):
         """
         Constructor.
 
@@ -334,8 +334,6 @@ class URLHandler(object):
         :type options:  optparse.OptionParser
         :type config:   Initialised ConfigParser.SafeConfigParser instance
         """
-        self._options = options
-
         assert config
         self._config = config
 
@@ -347,6 +345,9 @@ class URLHandler(object):
         self._lang_dir_template = self._config.string_template(
             'language_dir_format')
         self._filename_template = self._config.string_template('file_format')
+        self._custom_dump = []
+        if options and options.custom_dump:
+            self._custom_dump.extend(options.custom_dump)
 
     def language_dir(self, language):
         """Get the directory for given language
@@ -392,9 +393,8 @@ class URLHandler(object):
         :returns:   The latest dump date
         :rtype:     datetime.datetime
         """
-        pairs = self._options.custom_dump or []
         custom_dates = dict(
-            [pair.split(':', 1) for pair in pairs])
+            [pair.split(':', 1) for pair in self._custom_dump])
         if language in custom_dates:
             return datetime.datetime.strptime(custom_dates[language], '%Y%m%d')
 

--- a/lib/wp_download/download.py
+++ b/lib/wp_download/download.py
@@ -95,7 +95,7 @@ class WPDownloader(object):
         """
         self._options = options
         self._config = wpd_conf.Configuration(options)
-        self._urlhandler = URLHandler(self._config)
+        self._urlhandler = URLHandler(options, self._config)
         self._downloader = urllib.FancyURLopener()
 
         LOG.info('Set timeout to %d' % (options.timeout))
@@ -326,13 +326,16 @@ class URLHandler(object):
     Handler for Wikipedia dump download URLs
     """
 
-    def __init__(self, config):
+    def __init__(self, options, config):
         """
         Constructor.
 
         :param config:	Configuration
+        :type options:  optparse.OptionParser
         :type config:   Initialised ConfigParser.SafeConfigParser instance
         """
+        self._options = options
+
         assert config
         self._config = config
 
@@ -389,6 +392,12 @@ class URLHandler(object):
         :returns:   The latest dump date
         :rtype:     datetime.datetime
         """
+        pairs = self._options.custom_dump or []
+        custom_dates = dict(
+            [pair.split(':', 1) for pair in pairs])
+        if language in custom_dates:
+            return datetime.datetime.strptime(custom_dates[language], '%Y%m%d')
+
         dates = [ d for d in self.dump_dates(self.language_url(language)) ] + \
             [ datetime.datetime.strptime('19000101', '%Y%m%d') ]
         return max(dates)

--- a/scripts/wp-download
+++ b/scripts/wp-download
@@ -110,6 +110,12 @@ def init_parser():
                             help='Set number of download attempts '
                             '[default: %default]')
 
+    down_options.add_option('--custom-dump',
+                            action='append', dest='custom_dump',
+                            metavar='LANG:DATE',
+                            help='Download a custom dump for specific language '
+                            '(e.g., en:20150603)')
+
     new_parser.add_option_group(down_options)
 
     return new_parser


### PR DESCRIPTION
This (rather hackish) feature is sometimes useful when one wants to back off to the any nearest date because the latest dump is still in progress.  This can be set up on multiple languages through repeating the option several times.  For example, setting `--custom-dump en:20150515 --custom-dump simple:20150406` would keep track of enwiki on May 15 and simplewiki on Apr 6.  Others remain unaffected.

One caveat with the code is the validity of dates is never checked -- it's probably not hard to spit out error messages when the dates are not in `URLHandler.dump_dates()`.
