### PR TITLE
Wikidata json support

### DIFF
--- a/examples/wpdownloadrc.sample
+++ b/examples/wpdownloadrc.sample
@@ -403,3 +403,9 @@ site_stats      = sql.gz
 #zh = True
 #zh_yue = True
 #zu = True
+
+# 'entities' is a pseudo-language that will download with wikidata json format, e.g.
+#   https://dumps.wikimedia.org/wikidatawiki/entities/20160711/wikidata-20160711-all.json.gz
+# using the pseudo-language 'wikidata' will download the older xml format, e.g.
+#   https://dumps.wikimedia.org/wikidatawiki/20160701/wikidatawiki-20160701-pages-articles.xml.bz2
+#entities = True

--- a/scripts/wp-download
+++ b/scripts/wp-download
@@ -155,7 +155,7 @@ def init_logging(options):
         log_file_handler = logging.FileHandler(
             options.log_file)
         log_file_handler.setLevel(
-            logging.getLevelName(options.log_level))
+            logging.getLevelName(options.log_file_level))
         log_file_handler.formatter = logging.Formatter(
             '[%(levelname)s]: %(message)s')
         LOG.addHandler(log_file_handler)

--- a/wp_download/download.py
+++ b/wp_download/download.py
@@ -350,7 +350,10 @@ class URLHandler(object):
         :param language:    ISO 631 language code
         :type language:     string
         """
-        return self._lang_dir_template.substitute(langcode=language)
+        if language == 'entities':
+            return 'wikidatawiki/entities'
+        else:
+            return self._lang_dir_template.substitute(langcode=language)
 
     def language_url(self, language):
         """Get the dump location for given language
@@ -421,8 +424,15 @@ class URLHandler(object):
         LOG.info('Latest dump for (%s) is from %s' % (
             language, latest.strftime('%A %d %B %Y')))
 
-        for filename in self._config.enabled_files():
-            server_path = '/'.join([
+        filetypes = self._config.enabled_files()
+        for filename in filetypes:
+            if language == 'entities':
+                server_path = '/'.join([
+                    self.language_dir(language),
+                    latest.strftime('%Y%m%d'),
+                    'wikidata-%s-all.json.gz' % latest.strftime('%Y%m%d')])
+            else:
+                server_path = '/'.join([
                     self.language_dir(language),
                     latest.strftime('%Y%m%d'),
                     self._filename_template.substitute(


### PR DESCRIPTION
Support for downloading wikidata json format.  wikidata xml format was already supported via Language=wikidata, because it happens to have the same directory structure as real languages.  But https://www.wikidata.org/wiki/Wikidata:Database_download recommends the json format dump instead.  Language=entities enables this.  It's a bit ugly to force wikidata/entities into a "language" but this minimized the code changes.